### PR TITLE
initialize addr in AddrSequence::do_self_test_compare

### DIFF
--- a/AddrSequence.cc
+++ b/AddrSequence.cc
@@ -354,7 +354,7 @@ void AddrSequence::free_all_buf()
 
 int AddrSequence::do_self_test_compare(unsigned long pagesize, bool is_perf)
 {
-  unsigned long addr;
+  unsigned long addr = 0;
   uint8_t payload = 0;
 
   cout << "addr_clusters.size = " << addr_clusters.size() << endl;


### PR DESCRIPTION
This patch intends to initialize local var addr in
AddrSequence::do_self_test_compare to avoid a compiling warning.